### PR TITLE
Add Forgejo well-known pointer

### DIFF
--- a/.well-known/forgejo/server
+++ b/.well-known/forgejo/server
@@ -1,0 +1,3 @@
+{
+  "m.server": "git.rusz.dev:443"
+}

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ timezone: America/New_York
 
 include:
   - _pages
+  - .well-known
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
Setting up to move Forgejo to the rusz.dev domain.
